### PR TITLE
ancient.devices: Add Motorola Khaje family devices

### DIFF
--- a/ancient.devices
+++ b/ancient.devices
@@ -39,3 +39,6 @@ vayu
 violet
 whyred
 X00TD
+devon
+hawao
+rhode


### PR DESCRIPTION
Moto G32 (devon)
Moto G42 (hawao)
Moto G52 (rhode)