### PR TITLE
Add Exynos7885 Devices to the Official list

### DIFF
--- a/ancient.devices
+++ b/ancient.devices
@@ -48,3 +48,8 @@ devon
 hawao
 rhode
 a52q
+a10
+a20
+a20e
+a30
+a40


### PR DESCRIPTION
This are Galaxy A10,A20,A20e,A30,A40